### PR TITLE
Allow aliases to appear in top-level help

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/bin/run",
+            "outFiles": [
+                "${workspaceFolder}/lib/**/*.js"
+            ],
+            "skipFiles": [
+                "<node_internals>/**/async_hooks.js",
+                "<node_internals>/**/inspector_async_hook.js"
+            ],
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@oclif/plugin-help",
+  "name": "@unboundedsystems/plugin-help",
   "description": "standard help for oclif",
   "version": "2.1.6",
   "author": "Jeff Dickey @jdxcode",

--- a/test/commands/help.test.ts
+++ b/test/commands/help.test.ts
@@ -1,7 +1,8 @@
 import {expect, test} from '@oclif/test'
 
 const VERSION = require('../../package.json').version
-const UA = `@oclif/plugin-help/${VERSION} ${process.platform}-${process.arch} node-${process.version}`
+const NAME = require('../../package.json').name
+const UA = `${NAME}/${VERSION} ${process.platform}-${process.arch} node-${process.version}`
 
 describe('help command', () => {
   test

--- a/test/root.test.ts
+++ b/test/root.test.ts
@@ -6,7 +6,8 @@ g.columns = 80
 import Help from '../src'
 
 const VERSION = require('../package.json').version
-const UA = `@oclif/plugin-help/${VERSION} ${process.platform}-${process.arch} node-${process.version}`
+const NAME = require('../package.json').name
+const UA = `${NAME}/${VERSION} ${process.platform}-${process.arch} node-${process.version}`
 
 const test = base
 .loadConfig()


### PR DESCRIPTION
A couple of background notes on the implementation here:

- The hope here is to eventually get a PR submitted upstream with similar functionality.
- We don't want to change the default behavior of aliases & help.
- The @oclif repos are very tightly coupled when it comes to the Command type, where aliases are configured.
- The entirety of configuration of aliases is a static string array of names on the Command class, so there's no good place to put additional alias config without also changing Command (which would pretty much require us to fork all remaining @oclif repos, just to maintain that type difference).

Due to the above considerations, I chose to configure the non-default alias behavior in the "oclif" section of package.json and to require explicit opt-in for every alias you want to show up in the top level help.